### PR TITLE
Set LoadUserProfile on Windows only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ bld/
 # Visual Studio 2015 cache/options directory
 .vs/
 lib/
+.idea/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/src/Code/Diagnostics/Command.cs
+++ b/src/Code/Diagnostics/Command.cs
@@ -81,13 +81,17 @@ namespace Code.Diagnostics
 					FileName = commandType == CommandType.Terminal ? terminalFileName : command,
 					Arguments = commandType == CommandType.Terminal ? "" : arguments,
 					UseShellExecute = useShellExecute,
-					LoadUserProfile = useShellExecute,
 					WorkingDirectory = Environment.CurrentDirectory,
 					RedirectStandardInput = !useShellExecute,
 					RedirectStandardOutput = !useShellExecute,
 					RedirectStandardError = !useShellExecute
 				}
 			};
+
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				process.StartInfo.LoadUserProfile = useShellExecute;
+			}
 
 			try
 			{


### PR DESCRIPTION
In .NET 6, when I try to use `Commad.Run` I'm getting an error saying `LoadUserProfile` is not supported on Linux machines, this PR is going to force set `LoadUserProfile` only on Windows machines since it only supports there.